### PR TITLE
Message when require login after access denied

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -14,6 +14,7 @@ fr:
     failure_after_create:
       "Adresse e-mail ou mot de passe incorrect. Voulez-vous créer un nouveau compte ?
        <a href='%{sign_up_path}'>S'inscrire</a>."
+    failure_when_access_denied: "S'il vous plaît, vous devez vous identifier"
   helpers:
     submit:
       password:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -12,6 +12,8 @@ pt-BR:
       "Senha não pode ficar em branco."
     failure_after_create:
       "Email ou senha não encontrados. Deseja criar uma nova conta? <a href='%{sign_up_path}'>Registrar-se</a>."
+    failure_when_access_denied:
+      "Por favor, efetue login."
   helpers:
     submit:
       password:


### PR DESCRIPTION
This adds brazilian portuguese and french messages for failure_when_access_denied key.

This PR is refered to the thoughtbot/clearance#562 issue.