### PR TITLE
Remove Clearance version dependency

### DIFF
--- a/clearance-i18n.gemspec
+++ b/clearance-i18n.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
   s.files = Dir['{config,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'clearance', '~> 1.0.0'
+  s.add_dependency 'clearance'
   s.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
Users can now use Clearance-i18n with any version of Clearance.