### PR TITLE
Fix the bundler incompatibility 

### DIFF
--- a/clearance-i18n.gemspec
+++ b/clearance-i18n.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
   s.files = Dir['{config,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'clearance', '~> 1.0.0'
+  s.add_dependency 'clearance', '~> 1.15.0'
   s.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
This addresses #11 . Clearance is at v1.15 but the clearance-i18n gem is locked at 1.0 which prevents bundler for installing the gem.
@JulienItard let me know if this is correct. 