### PR TITLE
add missing translations to ru locale

### DIFF
--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -19,6 +19,10 @@ ru:
         email: Email
       password_reset:
         password: Введите новый пароль
+      session:
+        password: Пароль
+      user:
+        password: Пароль
     submit:
       password:
         submit: Сброс пароля


### PR DESCRIPTION
Password translations turn out to be missing even in original clearance.en.yml