### PR TITLE
updating bundler dependency for clearance to 1.16

### DIFF
--- a/clearance-i18n.gemspec
+++ b/clearance-i18n.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
   s.files = Dir['{config,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'clearance', '~> 1.15.0'
+  s.add_dependency 'clearance', '~> 1.16.0'
   s.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
Updating the bundler dependency to version ~> 1.16.0.