### PR TITLE
Fix typo

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -60,7 +60,7 @@ fr:
   sessions:
     form:
       forgot_password:
-        'Mot de pass oublié ?'
+        'Mot de passe oublié ?'
       sign_up:
         "S'incrire"
     new:


### PR DESCRIPTION
The word `pass` in french ends with the `e` letter