### PR TITLE
Call dynamic-readme reusable workflow

### DIFF
--- a/.github/workflows/dynamic-readme.yml
+++ b/.github/workflows/dynamic-readme.yml
@@ -1,0 +1,17 @@
+name: update-templates
+
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-templates:
+    permissions:
+      contents: write
+      pull-requests: write
+      pages: write
+    uses: thoughtbot/templates/.github/workflows/dynamic-readme.yaml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -20,16 +20,14 @@ Bundle:
 
 ## Credits
 
-![thoughtbot](https://thoughtbot.com/brand_assets/93:44.svg)
-
-Clearance I18n is maintained by [thoughtbot, inc](http://thoughtbot.com/community)
-and [contributors] like you. Thank you!
+Thank you, [contributors]!
 
 [contributors]: https://github.com/thoughtbot/clearance-i18n/contributors
 
 ## License
 
-Clearance I18n is copyright © 2013-2023 thoughtbot. It is free software, and may be
+Clearance I18n is copyright © 2013-2024 thoughtbot. It is free software, and may be
 redistributed under the terms specified in the `LICENSE` file.
 
-The names and logos for thoughtbot are trademarks of thoughtbot, inc.
+<!-- START /templates/footer.md -->
+<!-- END /templates/footer.md -->

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Thank you, [contributors]!
 
 ## License
 
-Clearance I18n is copyright © 2013-2024 thoughtbot. It is free software, and may be
+Clearance I18n is copyright © 2013 thoughtbot. It is free software, and may be
 redistributed under the terms specified in the `LICENSE` file.
 
 <!-- START /templates/footer.md -->


### PR DESCRIPTION
We want to have a way to edit our README footer at one place and have the changes from there be propagated to our repos.

By adding this snippet in the README, we call this reusable workflow: https://github.com/thoughtbot/templates/blob/main/.github/workflows/dynamic-readme.yaml that renders and updates the README footer dynamically.