### PR TITLE
Update `File.exists?` to `File.exist?` in spec boot

### DIFF
--- a/spec/clearance/i18n/railtie_spec.rb
+++ b/spec/clearance/i18n/railtie_spec.rb
@@ -3,6 +3,6 @@ require 'spec_helper'
 describe Clearance::I18n::Railtie do
   it 'adds locales to the i18n path' do
     reset_password = I18n.t('helpers.submit.password.submit', locale: :fr)
-    expect(reset_password).to eq('Réinitialiser votre mot de passe')
+    expect(reset_password).to eq('Réinitialiser le mot de passe')
   end
 end

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,5 +1,5 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 $LOAD_PATH.unshift File.expand_path('../../../../lib', __FILE__)


### PR DESCRIPTION
File.exists? was deprecated in Ruby 2.2 and removed in Ruby 3.2.

This change also updates the test string for French.